### PR TITLE
add `file_path` to logger API

### DIFF
--- a/lib/logsly.rb
+++ b/lib/logsly.rb
@@ -68,6 +68,12 @@ module Logsly
       end
     end
 
+    def file_path
+      @file_path ||= if (appender = get_file_appender)
+        appender.name if appender.respond_to?(:name)
+      end
+    end
+
     # delegate all calls to the @logger
 
     def method_missing(method, *args, &block)
@@ -101,6 +107,10 @@ module Logsly
       @logger.appenders.detect do |existing|
         existing.kind_of?(appender.class) && existing.name == appender.name
       end
+    end
+
+    def get_file_appender
+      @logger.appenders.detect{ |a| a.kind_of?(Logging::Appenders::File) }
     end
 
   end

--- a/logsly.gemspec
+++ b/logsly.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.13"])
+  gem.add_development_dependency("assert", ["~> 2.15"])
 
   gem.add_dependency("ns-options",  ["~> 1.1"])
   gem.add_dependency("logging",     ["~> 1.7"])

--- a/test/unit/logsly_tests.rb
+++ b/test/unit/logsly_tests.rb
@@ -106,6 +106,7 @@ module Logsly
     subject{ @logger }
 
     should have_readers :log_type, :level, :outputs, :logger
+    should have_imeths :file_path
 
     should "know its log_type" do
       assert_equal 'testy_log_logger', subject.log_type
@@ -139,6 +140,10 @@ module Logsly
       assert_equal Logging::LEVELS['debug'], log.logger.level
     end
 
+    should "not have a file path if no file appender is specified" do
+      assert_nil subject.file_path
+    end
+
   end
 
   class AppenderTests < UnitTests
@@ -158,6 +163,7 @@ module Logsly
     should "add a named stdout appender" do
       log = TestLogger.new(:test, :outputs => 'my_stdout')
       assert_includes_appender Logging::Appenders::Stdout, log
+      assert_nil log.file_path
     end
 
     should "add a named file appender" do
@@ -166,11 +172,13 @@ module Logsly
 
       assert_includes_appender Logging::Appenders::File, log
       assert_equal 'log/development-test.log', filelog.name
+      assert_equal 'log/development-test.log', log.file_path
     end
 
     should "add a named syslog appender" do
       log = TestLogger.new(:test, :outputs => 'my_syslog')
       assert_includes_appender Logging::Appenders::Syslog, log
+      assert_nil log.file_path
     end
 
     should "not add duplicate appenders" do
@@ -203,7 +211,7 @@ module Logsly
         Logging::Appenders::Stdout
       end
 
-      logger.appenders.select{|a| a.is_a?(klass)}.first
+      logger.appenders.detect{ |a| a.is_a?(klass) }
     end
 
   end


### PR DESCRIPTION
This method returns the path for any file appenders that have been
added to the logger.  If no file appenders have been added or the
logger file appender api changes, this method just returns `nil`.

The goal here is to easily grab any log file path if you are logging
to a file with a logger.

@jcredding ready for review.