### PR TITLE
expose an MDC api to set thread-local MDC key/value pairs

### DIFF
--- a/lib/logsly.rb
+++ b/lib/logsly.rb
@@ -68,6 +68,10 @@ module Logsly
       end
     end
 
+    def mdc(key, value)
+      Logging.mdc[key] = value
+    end
+
     def file_path
       @file_path ||= if (appender = get_file_appender)
         appender.name if appender.respond_to?(:name)

--- a/test/unit/logsly_tests.rb
+++ b/test/unit/logsly_tests.rb
@@ -106,7 +106,7 @@ module Logsly
     subject{ @logger }
 
     should have_readers :log_type, :level, :outputs, :logger
-    should have_imeths :file_path
+    should have_imeths :mdc, :file_path
 
     should "know its log_type" do
       assert_equal 'testy_log_logger', subject.log_type
@@ -138,6 +138,15 @@ module Logsly
 
       log = TestLogger.new('test', :level => :debug)
       assert_equal Logging::LEVELS['debug'], log.logger.level
+    end
+
+    should "set mdc key/value pairs" do
+      key = Factory.string
+      assert_nil Logging.mdc[key]
+
+      value = Factory.string
+      subject.mdc(key, value)
+      assert_equal value, Logging.mdc[key]
     end
 
     should "not have a file path if no file appender is specified" do


### PR DESCRIPTION
This exposes Logging's MDC api to allow setting thread-local key/value
pairs.  This is useful when you want to set state information to
use in all log entries (ie process/thread ids).  Setting key values
makes them available for use in log patterns.

@jcredding ready for review.