### PR TITLE
remove ns-options as a dependency

### DIFF
--- a/lib/logsly/colors.rb
+++ b/lib/logsly/colors.rb
@@ -1,12 +1,13 @@
-require 'ostruct'
-require 'ns-options'
-
 # This class provides a DSL for setting color scheme values and lazy eval's
 # the DSL to generate a Logging color scheme object.
 # See https://github.com/TwP/logging/blob/master/lib/logging/color_scheme.rb
 # for details on Logging color schemes.
 
 module Logsly
+
+  class NullColors
+    def to_scheme(*args); nil;  end
+  end
 
   class Colors
 
@@ -24,49 +25,133 @@ module Logsly
 
   end
 
-  class NullColors < OpenStruct
-    def to_scheme(*args); nil;  end
-  end
-
   class ColorsData
-    include NsOptions::Proxy
-
-    # color for the level text only
-    option :debug
-    option :info
-    option :warn
-    option :error
-    option :fatal
-
-    # color for the entire log message based on the value of the log level
-    option :debug_line
-    option :info_line
-    option :warn_line
-    option :error_line
-    option :fatal_line
-
-    option :logger      # [%c] name of the logger that generate the log event
-    option :date        # [%d] datestamp
-    option :message     # [%m] the user supplied log message
-    option :pid         # [%p] PID of the current process
-    option :time        # [%r] the time in milliseconds since the program started
-    option :thread      # [%T] the name of the thread Thread.current[:name]
-    option :thread_id   # [%t] object_id of the thread
-    option :file        # [%F] filename where the logging request was issued
-    option :line        # [%L] line number where the logging request was issued
-    option :method_name # [%M] method name where the logging request was issued
 
     def initialize(*args, &build)
       self.instance_exec(*args, &build)
 
-      @properties     = properties.map{|p| self.send(p)}
+      @properties     = properties.map{ |p| self.send(p) }
       @method         = self.method_name
-      @level_settings = levels.map{|l| self.send(l)}
-      @line_settings  = levels.map{|l| self.send("#{l}_line")}
+      @level_settings = levels.map{ |l| self.send(l) }
+      @line_settings  = levels.map{ |l| self.send("#{l}_line") }
 
       if has_level_settings? && has_line_settings?
         raise ArgumentError, "can't set line and level settings in the same scheme"
       end
+    end
+
+    # color for the level text only
+
+    def debug(value = nil)
+      @debug = value if !value.nil?
+      @debug
+    end
+
+    def info(value = nil)
+      @info = value if !value.nil?
+      @info
+    end
+
+    def warn(value = nil)
+      @warn = value if !value.nil?
+      @warn
+    end
+
+    def error(value = nil)
+      @error = value if !value.nil?
+      @error
+    end
+
+    def fatal(value = nil)
+      @fatal = value if !value.nil?
+      @fatal
+    end
+
+    # color for the entire log message based on the value of the log level
+
+    def debug_line(value = nil)
+      @debug_line = value if !value.nil?
+      @debug_line
+    end
+
+    def info_line(value = nil)
+      @info_line = value if !value.nil?
+      @info_line
+    end
+
+    def warn_line(value = nil)
+      @warn_line = value if !value.nil?
+      @warn_line
+    end
+
+    def error_line(value = nil)
+      @error_line = value if !value.nil?
+      @error_line
+    end
+
+    def fatal_line(value = nil)
+      @fatal_line = value if !value.nil?
+      @fatal_line
+    end
+
+    # [%c] name of the logger that generate the log event
+    def logger(value = nil)
+      @logger = value if !value.nil?
+      @logger
+    end
+
+    # [%d] datestamp
+    def date(value = nil)
+      @date = value if !value.nil?
+      @date
+    end
+
+    # [%m] the user supplied log message
+    def message(value = nil)
+      @message = value if !value.nil?
+      @message
+    end
+
+    # [%p] PID of the current process
+    def pid(value = nil)
+      @pid = value if !value.nil?
+      @pid
+    end
+
+    # [%r] the time in milliseconds since the program started
+    def time(value = nil)
+      @time = value if !value.nil?
+      @time
+    end
+
+    # [%T] the name of the thread Thread.current[:name]
+    def thread(value = nil)
+      @thread = value if !value.nil?
+      @thread
+    end
+
+    # [%t] object_id of the thread
+    def thread_id(value = nil)
+      @thread_id = value if !value.nil?
+      @thread_id
+    end
+
+    # [%F] filename where the logging request was issued
+    def file(value = nil)
+      @file = value if !value.nil?
+      @file
+    end
+
+    # [%L] line number where the logging request was issued
+    def line(value = nil)
+      @line = value if !value.nil?
+      @line
+    end
+
+    # [%M] method name where the logging request was issued
+    def method_name(value = nil)
+      @method_name = value if !value.nil?
+      @method_name
     end
 
     def to_scheme_opts

--- a/logsly.gemspec
+++ b/logsly.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("ns-options",  ["~> 1.1.6"])
+  gem.add_dependency("much-plugin", ["~> 0.2.0"])
   gem.add_dependency("logging",     ["~> 1.7"])
 
 end

--- a/test/unit/colors_tests.rb
+++ b/test/unit/colors_tests.rb
@@ -90,21 +90,21 @@ class Logsly::Colors
         method_name :white
         info        :blue
       end
-      expected = {
+      exp = {
         :date    => :blue,
         :message => :cyan,
         :method  => :white,
         :levels  => {:info  => :blue},
       }
 
-      assert_equal expected, general_only.to_scheme_opts
+      assert_equal exp, general_only.to_scheme_opts
     end
 
     should "only include :levels and :lines if at least one is set" do
       no_levels_lines = Logsly::ColorsData.new { date :blue }
-      expected = { :date => :blue }
+      exp = { :date => :blue }
 
-      assert_equal expected, no_levels_lines.to_scheme_opts
+      assert_equal exp, no_levels_lines.to_scheme_opts
     end
 
   end

--- a/test/unit/logsly_tests.rb
+++ b/test/unit/logsly_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'logsly'
 
 require 'logging'
+require 'logsly/colors'
 require 'logsly/outputs'
 require 'test/support/logger'
 
@@ -130,8 +131,8 @@ module Logsly
     end
 
     should "create the Logging::Logger with a unique name" do
-      expected = "#{subject.class.name}-testy_log_logger-#{subject.object_id}"
-      assert_equal expected, subject.logger.name
+      exp = "#{subject.class.name}-testy_log_logger-#{subject.object_id}"
+      assert_equal exp, subject.logger.name
     end
 
     should "set the logger's level" do

--- a/test/unit/outputs_tests.rb
+++ b/test/unit/outputs_tests.rb
@@ -73,7 +73,7 @@ module Logsly::Outputs
     end
     subject{ @data }
 
-    should have_readers :pattern, :colors
+    should have_imeths :pattern, :colors
 
     should "know its defaults" do
       data = BaseData.new
@@ -177,7 +177,7 @@ module Logsly::Outputs
     end
     subject{ @data }
 
-    should have_imeth :path
+    should have_imeths :path
 
   end
 


### PR DESCRIPTION
This is part of getting this gem working in modern ruby versions.
We are moving away from using ns-options as a dependency b/c it
has performance issues when accessing options and on top of that
its API hasn't proven to be especially useful over a struct-like
class.

NsOptions was used in a variety of contexts in this gem:

* I switched the main Settings to be a simple class that gets
  set to `nil` on reset
* I removed the NsOptions::Struct in the main intialize method in
  favor of just manually processing the opts
* I updated the both the colors and outputs to just manually
  define their data DSL meths and manually handle any defaults

This is prep or getting this gem working in modern ruby versions.

@jcredding ready for review.