### PR TITLE
get implementation, tests working in modern Ruby versions

### DIFF
--- a/lib/logsly.rb
+++ b/lib/logsly.rb
@@ -51,7 +51,7 @@ module Logsly
 
       @log_type = log_type.to_s
       @level    = (opts[:level]  || opts['level']   || 'info').to_s
-      @outputs  = opts[:outputs] || opts['outputs'] || []
+      @outputs  = [*(opts[:outputs] || opts['outputs'] || [])]
 
       unique_name   = "#{self.class.name}-#{@log_type}-#{self.object_id}"
       @logger       = Logsly::Logging182.logger[unique_name]

--- a/lib/logsly/logging182/diagnostic_context.rb
+++ b/lib/logsly/logging182/diagnostic_context.rb
@@ -95,7 +95,7 @@ module Logsly::Logging182
         Thread.current[NAME] = obj.dup
       when Thread
         return if Thread.current == obj
-        Thread.exclusive {
+        DIAGNOSTIC_MUTEX.synchronize {
           Thread.current[NAME] = obj[NAME].dup if obj[NAME]
         }
       end
@@ -217,7 +217,7 @@ module Logsly::Logging182
         Thread.current[NAME] = obj.dup
       when Thread
         return if Thread.current == obj
-        Thread.exclusive {
+        DIAGNOSTIC_MUTEX.synchronize {
           Thread.current[NAME] = obj[NAME].dup if obj[NAME]
         }
       end
@@ -260,7 +260,7 @@ module Logsly::Logging182
   #
   def self.clear_diagnostic_contexts( all = false )
     if all
-      Thread.exclusive {
+      DIAGNOSTIC_MUTEX.synchronize {
         Thread.list.each { |thread|
           thread[MappedDiagnosticContext::NAME].clear if thread[MappedDiagnosticContext::NAME]
           thread[NestedDiagnosticContext::NAME].clear if thread[NestedDiagnosticContext::NAME]
@@ -273,6 +273,8 @@ module Logsly::Logging182
 
     self
   end
+
+  DIAGNOSTIC_MUTEX = Mutex.new
 
 end  # module Logsly::Logging182
 

--- a/lib/logsly/logging182/layouts/pattern.rb
+++ b/lib/logsly/logging182/layouts/pattern.rb
@@ -148,53 +148,8 @@ module Logsly::Logging182::Layouts
   #
   class Pattern < ::Logsly::Logging182::Layout
 
-    # :stopdoc:
-
-    # Arguments to sprintf keyed to directive letters
-    DIRECTIVE_TABLE = {
-      'c' => 'event.logger'.freeze,
-      'd' => 'format_date(event.time)'.freeze,
-      'F' => 'event.file'.freeze,
-      'l' => '::Logsly::Logging182::LNAMES[event.level]'.freeze,
-      'L' => 'event.line'.freeze,
-      'm' => 'format_obj(event.data)'.freeze,
-      'M' => 'event.method'.freeze,
-      'p' => 'Process.pid'.freeze,
-      'r' => 'Integer((event.time-@created_at)*1000).to_s'.freeze,
-      't' => 'Thread.current.object_id.to_s'.freeze,
-      'T' => 'Thread.current[:name]'.freeze,
-      'X' => :placeholder,
-      'x' => :placeholder,
-      '%' => :placeholder
-    }.freeze
-
-    # Matches the first directive encountered and the stuff around it.
-    #
-    # * $1 is the stuff before directive or "" if not applicable
-    # * $2 is the %#.# match within directive group
-    # * $3 is the directive letter
-    # * $4 is the precision specifier for the logger name
-    # * $5 is the stuff after the directive or "" if not applicable
-    DIRECTIVE_RGXP = %r/([^%]*)(?:(%-?\d*(?:\.\d+)?)([a-zA-Z%])(?:\{([^\}]+)\})?)?(.*)/m
-
     # default date format
     ISO8601 = "%Y-%m-%d %H:%M:%S".freeze
-
-    # Human name aliases for directives - used for colorization of tokens
-    COLOR_ALIAS_TABLE = {
-      'c' => :logger,
-      'd' => :date,
-      'm' => :message,
-      'p' => :pid,
-      'r' => :time,
-      'T' => :thread,
-      't' => :thread_id,
-      'F' => :file,
-      'L' => :line,
-      'M' => :method,
-      'X' => :mdc,
-      'x' => :ndc
-    }.freeze
 
     # call-seq:
     #    Pattern.create_date_format_methods( pf )
@@ -225,109 +180,19 @@ module Logsly::Logging182::Layouts
     end
 
     # call-seq:
-    #    Pattern.create_format_method( pf )
+    #    Pattern.create_format_method( pl )
     #
-    # This method will create the +format+ method in the given Pattern
-    # Layout _pf_ based on the configured format pattern specified by the
+    # This method will create the `format` method in the given Pattern
+    # Layout `pl` based on the configured format pattern specified by the
     # user.
     #
-    def self.create_format_method( pf )
-      # Create the format(event) method
-      format_string = '"'
-      pattern = pf.pattern.dup
-      color_scheme = pf.color_scheme
-      args = []
-      name_map_count = 0
+    def self.create_format_method( pl )
+      builder = FormatMethodBuilder.new(pl)
+      code = builder.build_code
 
-      while true
-        m = DIRECTIVE_RGXP.match(pattern)
-        format_string << m[1] unless m[1].empty?
-
-        case m[3]
-        when '%'; format_string << '%%'
-        when 'c'
-          fmt = m[2] + 's'
-          fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[m[3]]) if color_scheme and !color_scheme.lines?
-
-          format_string << fmt
-          args << DIRECTIVE_TABLE[m[3]].dup
-          if m[4]
-            precision = Integer(m[4]) rescue nil
-            if precision
-              raise ArgumentError, "logger name precision must be an integer greater than zero: #{precision}" unless precision > 0
-              args.last <<
-                  ".split(::Logsly::Logging182::Repository::PATH_DELIMITER)" \
-                  ".last(#{m[4]}).join(::Logsly::Logging182::Repository::PATH_DELIMITER)"
-            else
-              format_string << "{#{m[4]}}"
-            end
-          end
-        when 'l'
-          if color_scheme and color_scheme.levels?
-            name_map = ::Logsly::Logging182::LNAMES.map { |name| color_scheme.color(("#{m[2]}s" % name), name) }
-            var = "@name_map_#{name_map_count}"
-            pf.instance_variable_set(var.to_sym, name_map)
-            name_map_count += 1
-
-            format_string << '%s'
-            format_string << "{#{m[4]}}" if m[4]
-            args << "#{var}[event.level]"
-          else
-            format_string << m[2] + 's'
-            format_string << "{#{m[4]}}" if m[4]
-            args << DIRECTIVE_TABLE[m[3]]
-          end
-
-        when 'X'
-          raise ArgumentError, "MDC must have a key reference" unless m[4]
-          fmt = m[2] + 's'
-          fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[m[3]]) if color_scheme and !color_scheme.lines?
-
-          format_string << fmt
-          args << "::Logsly::Logging182.mdc['#{m[4]}']"
-
-        when 'x'
-          fmt = m[2] + 's'
-          fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[m[3]]) if color_scheme and !color_scheme.lines?
-
-          format_string << fmt
-          separator = m[4].to_s
-          separator = ' ' if separator.empty?
-          args << "::Logsly::Logging182.ndc.context.join('#{separator}')"
-
-        when *DIRECTIVE_TABLE.keys
-          fmt = m[2] + 's'
-          fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[m[3]]) if color_scheme and !color_scheme.lines?
-
-          format_string << fmt
-          format_string << "{#{m[4]}}" if m[4]
-          args << DIRECTIVE_TABLE[m[3]]
-
-        when nil; break
-        else
-          raise ArgumentError, "illegal format character - '#{m[3]}'"
-        end
-
-        break if m[5].empty?
-        pattern = m[5]
-      end
-
-      format_string << '"'
-
-      sprintf = "sprintf("
-      sprintf << format_string
-      sprintf << ', ' + args.join(', ') unless args.empty?
-      sprintf << ")"
-
-      if color_scheme and color_scheme.lines?
-        sprintf = "color_scheme.color(#{sprintf}, ::Logsly::Logging182::LNAMES[event.level])"
-      end
-
-      code = "undef :format if method_defined? :format\n"
-      code << "def format( event )\n#{sprintf}\nend\n"
       ::Logsly::Logging182.log_internal(0) {code}
 
-      pf._meta_eval(code, __FILE__, __LINE__)
+      pl._meta_eval(code, __FILE__, __LINE__)
     end
     # :startdoc:
 
@@ -418,6 +283,283 @@ module Logsly::Logging182::Layouts
     def _meta_eval( code, file = nil, line = nil )
       meta = class << self; self end
       meta.class_eval code, file, line
+    end
+    # :startdoc:
+
+    # This class is used to build the `format` method for the Pattern layout. It
+    # parses the user defined pattern and emits Ruby source code (as a string)
+    # that can be `eval`d in the context of the Pattern layout instance.
+    class FormatMethodBuilder
+      # Matches the first directive encountered and the stuff around it.
+      #
+      # * $1 is the stuff before directive or "" if not applicable
+      # * $2 is the %#.# match within directive group
+      # * $3 is the directive letter
+      # * $4 is the precision specifier for the logger name
+      # * $5 is the stuff after the directive or "" if not applicable
+      DIRECTIVE_RGXP = %r/([^%]*)(?:(%-?\d*(?:\.\d+)?)([a-zA-Z%])(?:\{([^\}]+)\})?)?(.*)/m
+
+      # Arguments to sprintf keyed to directive letters
+      DIRECTIVE_TABLE = {
+        'c' => 'event.logger'.freeze,
+        'd' => 'format_date(event.time)'.freeze,
+        'F' => 'event.file'.freeze,
+        'l' => 'Logsly::Logging182::LNAMES[event.level]'.freeze,
+        'L' => 'event.line'.freeze,
+        'm' => 'format_obj(event.data)'.freeze,
+        'M' => 'event.method'.freeze,
+        'h' => "'#{Socket.gethostname}'".freeze,
+        'p' => 'Process.pid'.freeze,
+        'r' => 'Integer((event.time-@created_at)*1000).to_s'.freeze,
+        't' => 'Thread.current.object_id.to_s'.freeze,
+        'T' => 'Thread.current[:name]'.freeze,
+        'X' => :placeholder,
+        'x' => :placeholder,
+        '%' => :placeholder
+      }.freeze
+
+      # Human name aliases for directives - used for colorization of tokens
+      COLOR_ALIAS_TABLE = {
+        'c' => :logger,
+        'd' => :date,
+        'm' => :message,
+        'h' => :hostname,
+        'p' => :pid,
+        'r' => :time,
+        'T' => :thread,
+        't' => :thread_id,
+        'F' => :file,
+        'L' => :line,
+        'M' => :method,
+        'X' => :mdc,
+        'x' => :ndc
+      }.freeze
+
+      attr_reader :layout
+      attr_accessor :pattern
+      attr_reader :color_scheme
+      attr_reader :sprintf_args
+      attr_reader :format_string
+      attr_accessor :name_map_count
+
+      # Creates the format method builder and initializes some variables from
+      # the given Patter layout instance.
+      #
+      # pattern_layout - The Pattern Layout instance
+      #
+      def initialize( pattern_layout )
+        @layout         = pattern_layout
+        @pattern        = layout.pattern.dup
+        @color_scheme   = layout.color_scheme
+
+        @sprintf_args   = []
+        @format_string  = '"'
+        @name_map_count = 0
+      end
+
+      # Returns `true` if the log messages should be colorized.
+      def colorize?
+        color_scheme && !color_scheme.lines?
+      end
+
+      # Returns `true` if the log messages should be colorized by line.
+      def colorize_lines?
+        color_scheme && color_scheme.lines?
+      end
+
+      # Returns `true` if the log levels have special colorization defined.
+      def colorize_levels?
+        color_scheme && color_scheme.levels?
+      end
+
+      # This method returns a String which can be `eval`d in the context of the
+      # Pattern layout. When it is `eval`d, a `format` method is defined in the
+      # Pattern layout.
+      #
+      # At the heart of the format method is `sprintf`. The conversion pattern
+      # specified in the Pattern layout is parsed and converted into a format
+      # string and corresponding arguments list. The format string and arguments
+      # are then processed by `sprintf` to format log events.
+      #
+      # Returns a Ruby code as a String.
+      def build_code
+        build_format_string
+
+        sprintf = "sprintf("
+        sprintf << format_string
+        sprintf << ', ' + sprintf_args.join(', ') unless sprintf_args.empty?
+        sprintf << ")"
+
+        if colorize_lines?
+          sprintf = "color_scheme.color(#{sprintf}, Logsly::Logging182::LNAMES[event.level])"
+        end
+
+        code = "undef :format if method_defined? :format\n"
+        code << "def format( event )\n#{sprintf}\nend\n"
+      end
+
+      # This method builds the format string used by `sprintf` to format log
+      # events. The conversion pattern given by the user is iteratively parsed
+      # by a regular expression into separate format directives. Each directive
+      # builds up the format string and the corresponding arguments list that
+      # will be formatted.
+      #
+      # The actual building of the format string is handled by separate
+      # directive specific methods. Those handlers also populate the arguments
+      # list passed to `sprintf`.
+      #
+      # Returns the format String.
+      def build_format_string
+        while true
+          match = DIRECTIVE_RGXP.match(pattern)
+          _, pre, format, directive, precision, post = *match
+          format_string << pre unless pre.empty?
+
+          case directive
+          when '%'; format_string << '%%'
+          when 'c'; handle_logger( format, directive, precision )
+          when 'l'; handle_level(  format, directive, precision )
+          when 'X'; handle_mdc(    format, directive, precision )
+          when 'x'; handle_ndc(    format, directive, precision )
+
+          when *DIRECTIVE_TABLE.keys
+            handle_directives(format, directive, precision)
+
+          when nil; break
+          else
+            raise ArgumentError, "illegal format character - '#{directive}'"
+          end
+
+          break if post.empty?
+          self.pattern = post
+        end
+
+        format_string << '"'
+      end
+
+      # Add the logger name to the `format_string` and the `sprintf_args`. The
+      # `slice` argument is a little interesting - this is the number of logger
+      # name segments to keep. If we have a logger named "Foo::Bar::Baz" and our
+      # `slice` is 2, then "Bar::Baz" will appear in the generated log message.
+      # So the `slice` selects the last two parts of the logger name.
+      #
+      # format    - format String
+      # directive - the directive character ('c')
+      # slice     - the number of name segments to keep
+      #
+      # Returns nil
+      def handle_logger( format, directive, slice )
+        fmt = format + 's'
+        fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[directive]) if colorize?
+
+        format_string << fmt
+        sprintf_args << DIRECTIVE_TABLE[directive].dup
+
+        if slice
+          numeric = Integer(slice) rescue nil
+          if numeric
+            raise ArgumentError, "logger name slice must be an integer greater than zero: #{numeric}" unless numeric > 0
+            sprintf_args.last <<
+                ".split(Logsly::Logging182::Repository::PATH_DELIMITER)" \
+                ".last(#{slice}).join(Logsly::Logging182::Repository::PATH_DELIMITER)"
+          else
+            format_string << "{#{slice}}"
+          end
+        end
+
+        nil
+      end
+
+      # Add the log event level to the `format_string` and the `sprintf_args`.
+      # The color scheme is taken into account when formatting the log event
+      # level.
+      #
+      # format    - format String
+      # directive - the directive character ('l')
+      # precision - added back to the format string
+      #
+      # Returns nil
+      def handle_level( format, directive, precision )
+        if colorize_levels?
+          name_map = Logsly::Logging182::LNAMES.map do |name|
+            color_scheme.color(("#{format}s" % name), name)
+          end
+          var = "@name_map_#{name_map_count}"
+          layout.instance_variable_set(var.to_sym, name_map)
+          self.name_map_count += 1
+
+          format_string << '%s'
+          format_string << "{#{precision}}" if precision
+          sprintf_args << "#{var}[event.level]"
+        else
+          format_string << format + 's'
+          format_string << "{#{precision}}" if precision
+          sprintf_args << DIRECTIVE_TABLE[directive]
+        end
+
+        nil
+      end
+
+      # Add a Mapped Diagnostic Context to the `format_string` and the
+      # `sprintf_args`. Only one MDC value is added at a time, so this directive
+      # can appear multiple times using various keys.
+      #
+      # format    - format String
+      # directive - the directive character ('X')
+      # key       - which MDC value to add to the log message
+      #
+      # Returns nil
+      def handle_mdc( format, directive, key )
+        raise ArgumentError, "MDC must have a key reference" unless key
+        fmt = format + 's'
+        fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[directive]) if colorize?
+
+        format_string << fmt
+        sprintf_args << "::Logging.mdc['#{key}']"
+
+        nil
+      end
+
+      # Add a Nested Diagnostic Context to the `format_string` and the
+      # `sprintf_args`. Since the NDC is an Array of values, the directive will
+      # appear only once in the conversion pattern. A `separator` is inserted
+      # between the values in generated log message.
+      #
+      # format    - format String
+      # directive - the directive character ('x')
+      # separator - used to separate the values in the NDC array
+      #
+      # Returns nil
+      def handle_ndc( format, directive, separator )
+        fmt = format + 's'
+        fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[directive]) if colorize?
+
+        format_string << fmt
+        separator = separator.to_s
+        separator = ' ' if separator.empty?
+        sprintf_args << "::Logging.ndc.context.join('#{separator}')"
+
+        nil
+      end
+
+      # Handles the rest of the directives; none of these need any special
+      # handling.
+      #
+      # format    - format String
+      # directive - the directive character
+      # precision - added back to the format string
+      #
+      # Returns nil
+      def handle_directives( format, directive, precision )
+        fmt = format + 's'
+        fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[directive]) if colorize?
+
+        format_string << fmt
+        format_string << "{#{precision}}" if precision
+        sprintf_args << DIRECTIVE_TABLE[directive]
+
+        nil
+      end
     end
     # :startdoc:
 

--- a/test/unit/outputs_tests.rb
+++ b/test/unit/outputs_tests.rb
@@ -40,21 +40,31 @@ module Logsly::Outputs
     desc "given a build"
     setup do
       Logsly.colors('a_color_scheme') do
-        debug :white
+        debug_line :white
       end
       @out = Base.new do |*args|
-        pattern args.to_s
+        pattern args.first
         colors  'a_color_scheme'
       end
     end
 
     should "build a Logsly::Logging182 pattern layout" do
-      data = BaseData.new('%d : %m\n', &@out.build)
+      data = BaseData.new('[%c{2}] [%l] %d : %m :\n', &@out.build)
       lay = subject.to_layout(data)
 
       assert_kind_of Logsly::Logging182::Layout, lay
-      assert_equal   '%d : %m\n', lay.pattern
       assert_kind_of Logsly::Logging182::ColorScheme, lay.color_scheme
+      assert_equal '[%c{2}] [%l] %d : %m :\n', lay.pattern
+
+      assert_nothing_raised do
+        event = ::Logsly::Logging182::LogEvent.new(
+          Factory.string,
+          ::Logsly::Logging182::LEVELS['debug'],
+          {},
+          []
+        )
+        lay.format(event)
+      end
     end
 
   end


### PR DESCRIPTION
These are the things I needed to update to get the test suite
passing in modern Ruby versions.  I'll try and outline each change
below:

* force the `:outputs` option value to always be an array (we were
  getting away with passing a single string as `:outputs` b/c in
  ruby 1.8.7 String responds to `each` but not in modern Ruby)
* replace `Thread.exclusive` with a manual Mutex in Logging182's
  diagnostic context handling (`Thread.exclusive` is a thing in
  ruby 1.8.7 but not in modern ruby).
* fix a test in `output_tests.rb` to not blindly pass an the
  string representation of an `args` Array as a pattern (the test
  was getting away with this in ruby 1.8.7 b/c the string rep of
  an Array is just the string rep of the arrays items joined - in
  modern ruby the string rep of an Array looks more like the code
  rep, including brackets, etc - this broke the pattern handling
  for that test)
* make the base output tests more robust to catch some `Logging`
  renames I originally missed.

Note: I copied the Mutex handling from the latest version of
Logging to keep our copy as close to the original as possible.

Note also: In debugging that last pattern issue, I ended up
overwriting some of the pattern handling implementation with the
implementation from the latest version of Logging.  I feel this
implementation is much easier to read/understand and better
organizes the logic.

@jcredding ready for review.