### PR TITLE
switch to creating a Logging182 Logger per output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Logsly creates and delegates to a [Logging logger](https://github.com/TwP/loggin
 ## Settings
 
 * `log_type`: custom string used to identify the type of the logger
-* `level`: the level in use (default: `'debug'`)
+* `level`: the level in use (default: `'info'`)
 * `outputs`: list of named outputs to log to (default: `[]`)
 
 ## Outputs
@@ -41,8 +41,9 @@ Logsly creates and delegates to a [Logging logger](https://github.com/TwP/loggin
 
 ```ruby
 Logsly.stdout('my_stdout') do |logger|
+  level   'info' # (optional) if set, this level will be used instead of the logger's setting
   pattern '[%d %-5l] : %m\n'
-  colors  'my_colors'  # use the 'my_colors' color scheme
+  colors  'my_colors' # use the 'my_colors' color scheme
 end
 ```
 
@@ -54,6 +55,7 @@ Define a named stdout output to use with your loggers.  Pass a block to customiz
 Logsly.file('my_file') do |logger|
   path "development.log"
 
+  level   'debug' # log debug level when outputting to this file
   pattern '[%d %-5l] : %m\n'
   # don't use a color scheme
 end
@@ -69,6 +71,7 @@ Logsly.syslog('my_syslog') do |logger|
   facility Syslog::LOG_LOCAL0 # or whatever (default: `LOG_LOCAL0`)
   log_opts Syslog::LOG_PID    # or whatever (default: `(LOG_PID | LOG_CONS)`)
 
+  # no custom level set, just use the logger's setting
   pattern '%m\n'
   # don't use a color scheme
 end


### PR DESCRIPTION
This allows users to specify logger settings both on a global
and on a per-output basis.  For example, this allows saying one
output should log at the info level while another output logs at
the debug level.  Specifically, I want just this: Dk wants to use
a logger that logs to stdout on the INFO level while logging to
a file on the DEBUG level.

This switches to creating a Logging182 Logger per given output
and delegating all level method calls to each output's logger.
Note: this does potentially add a performance degredation since
each log statement has to run through multiple loggers under the
covers.

This also updates how outputs handle their data.  This is needed
b/c the data needs to be available on its own b/c it is needed
when building the output loggers.  Now the data is built and then
passed in to build the outputs appender. This adds a `level` DSL
method to the output datas so that it can be configured on
outputs. If an output's level is set, it will be used on the
output's logger. Otherwise, the logger will fall back to the
overall default level.

This change is backwards-compatible.  You can keep configuring
outputs as you did before and just setting the level on the logger
and nothing changes.  Everything works as it did before.  However,
you can now start specifying a level on your outputs and it will
be honored.

This also included a number of smaller cleanups:

* updated the README to show how output levels can be configured
* made the default level a formal constant
* removed the method missing delegation in favor of explicit
  Logging severity constant method definitions
* made the default output pattern a formal constant

@jcredding ready for review.  Like I mention in the commit, this is driven by a need in Dk.  I'm going to test this out in our apps to make sure it is truly backwards-compatible, but that is the intent.  Are you cool with this?  It does add a bit of overhead when you don't care about output-specific logger settings.