### PR TITLE
Use a passed in log level if output isn't configured with one

### DIFF
--- a/lib/logsly.rb
+++ b/lib/logsly.rb
@@ -63,7 +63,7 @@ module Logsly
         output_data = output.data(self)
 
         # prefer output-specific level; fall back to general level
-        logger.level = output_data ? output_data.level : @level
+        logger.level = output_data && output_data.level ? output_data.level : @level
         add_appender(logger, output.to_appender(output_data))
 
         hash[output_name] = logger


### PR DESCRIPTION
This updates the logic that builds a logger for each output to
use the passed in log level if the output wasn't configured with
a log level. This fixes an issue with a logger always using the
`DEBUG` level if an output doesn't configure a level to use.

Logsly looks up an outputs data to build a logger for the output.
If it's a configured output, the output data will return an object
depending on if its a stdout, file or syslog output. If the output
isn't configured then it returns `nil` for its output data. When
an output has been configured but a `level` hasn't been specified,
the output data will return `nil` for the `level`. Logsly was
previously always using the output data level if the output data
existed. This caused it to set the logger's level to `nil` which
defaulted to the `DEBUG` level. This updates logsly to check if
the output data and its level are not `nil` before using them. If
they are `nil` then the passed in log level is used instead. This
preserves using the configured log level if specified but allowing
it to properly fallback when an output is configured with no log
level. For unconfigured outputs that return `nil` for their output
data they are still defaulted to the `DEBUG` log level as before.

@kellyredding - Ready for review. This is causing `DEBUG` logs to be output in our production environments.